### PR TITLE
Libs: putting wt after connectors, and wtdbo after Wt::Dbo backends

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -184,11 +184,9 @@ class WtConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = ['wt']
+        self.cpp_info.libs = []
         if self.options.with_test:
             self.cpp_info.libs.append('wttest')
-        if self.options.with_dbo:
-            self.cpp_info.libs.append('wtdbo')
         if self.options.with_postgres:
             self.cpp_info.libs.append('wtdbopostgres')
         if self.options.with_sqlite:
@@ -199,6 +197,8 @@ class WtConan(ConanFile):
             self.cpp_info.libs.append('wtdbomssqlserver')
         if self.options.with_firebird:
             self.cpp_info.libs.append('wtdbofirebird')
+        if self.options.with_dbo:
+            self.cpp_info.libs.append('wtdbo')
         if self.options.connector_http:
             self.cpp_info.libs.append('wthttp')
         if self.settings.os == 'Windows':
@@ -207,6 +207,7 @@ class WtConan(ConanFile):
         else:
             if self.options.connector_fcgi:
                 self.cpp_info.libs.append('wtfcgi')
+        self.cpp_info.libs.append('wt')
         if self.settings.build_type == 'Debug':
             self.cpp_info.libs = ['%sd' % lib for lib in self.cpp_info.libs]
         if self.settings.os == 'Linux':


### PR DESCRIPTION
When static linking on Linux, the order matters.

wthttp, wtisapi, and wtfcgi depend on wt, so wt should be last

The Wt::Dbo backends depend on Wt::Dbo, so wtdbo should be last

This fixes static linking of projects using Wt on Linux when cmake
integration and `${CONAN_LIBS}` are used